### PR TITLE
Python 3.5-3.8 support

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -29,6 +29,6 @@ jobs:
     - name: Lint with pylint
       run: |
         scripts/lint
-    - name: Test with pytest
+    - name: test with tox
       run: |
-        scripts/cov
+        tox

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -16,10 +16,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
-	  with:
+      with:
           python-version: ${{ matrix.python }}
     - name: Install dependencies
-	  run: |
+      run: |
         python -m pip install --upgrade pip
         curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer
         pip3 install coverage
@@ -27,6 +27,6 @@ jobs:
     - name: Lint with pylint
       run: |
         scripts/lint
-	- name: Run Tox
-	  # Run tox using the version of Python in `PATH`
-	  run: tox -e py
+    - name: Run Tox
+      # Run tox using the version of Python in `PATH`
+      run: tox -e py

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -3,25 +3,23 @@
 
 name: Python application
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push]
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    strategy:
+        matrix:
+            python: [3.5, 3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
+    - name: Set up Python
+      uses: actions/setup-python@v2
+	  with:
+          python-version: ${{ matrix.python }}
     - name: Install dependencies
-      run: |
+	  run: |
         python -m pip install --upgrade pip
         curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer
         pip3 install coverage
@@ -29,6 +27,6 @@ jobs:
     - name: Lint with pylint
       run: |
         scripts/lint
-    - name: test with tox
-      run: |
-        tox
+	- name: Run Tox
+	  # Run tox using the version of Python in `PATH`
+	  run: tox -e py

--- a/.github/workflows/pythonreleasemac.yml
+++ b/.github/workflows/pythonreleasemac.yml
@@ -1,0 +1,35 @@
+name: Upload Github Release Mac
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+jobs:
+  deploy:
+    runs-on: macos-latest
+    steps:
+    - name: Build with pyinstaller
+      run: |
+        scripts/build
+      env:
+        TRAVIS_OS_NAME: mac 
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: true
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+        asset_path: ./dist/build/sperf-mac.zip
+        asset_name: sperf-mac.zip
+        asset_content_type: application/zip

--- a/.github/workflows/pythonreleasewin.yml
+++ b/.github/workflows/pythonreleasewin.yml
@@ -1,0 +1,35 @@
+name: Upload Github Release Windows
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+jobs:
+  deploy:
+    runs-on: windows-latest
+    steps:
+    - name: Build with pyinstaller
+      run: |
+        scripts/build
+      env:
+        TRAVIS_OS_NAME: windows 
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: true
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+        asset_path: ./dist/build/sperf-windows.zip
+        asset_name: sperf-windows.zip
+        asset_content_type: application/zip

--- a/.pylintrc
+++ b/.pylintrc
@@ -9,3 +9,4 @@ disable=C0103,
 
 [SIMILARITIES]
 ignore-docstrings=no
+min-similarity-lines=8

--- a/pysper/__init__.py
+++ b/pysper/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """top level module for sperf python port"""
-VERSION = "0.6.0"
+VERSION = "0.6.1-MASTER"

--- a/pysper/core/__init__.py
+++ b/pysper/core/__init__.py
@@ -1,0 +1,60 @@
+# Copyright 2020 DataStax, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" pysper core package"""
+from collections import OrderedDict, Callable
+
+class OrderedDefaultDict(OrderedDict):
+
+    # Source: http://stackoverflow.com/a/6190500/562769
+    def __init__(self, default_factory=None, *a, **kw):
+        if (default_factory is not None and
+           not isinstance(default_factory, Callable)):
+            raise TypeError('first argument must be callable')
+        OrderedDict.__init__(self, *a, **kw)
+        self.default_factory = default_factory
+
+    def __getitem__(self, key):
+        try:
+            return OrderedDict.__getitem__(self, key)
+        except KeyError:
+            return self.__missing__(key)
+
+    def __missing__(self, key):
+        if self.default_factory is None:
+            raise KeyError(key)
+        self[key] = value = self.default_factory()
+        return value
+
+    def __reduce__(self):
+        if self.default_factory is None:
+            args = tuple()
+        else:
+            args = self.default_factory,
+        return type(self), args, None, None, self.items()
+
+    def copy(self):
+        return self.__copy__()
+
+    def __copy__(self):
+        return type(self)(self.default_factory, self)
+
+    def __deepcopy__(self, memo):
+        import copy
+        return type(self)(self.default_factory,
+                          copy.deepcopy(self.items()))
+
+    def __repr__(self):
+        return 'OrderedDefaultDict(%s, %s)' % (self.default_factory,
+                                               OrderedDict.__repr__(self))

--- a/pysper/core/__init__.py
+++ b/pysper/core/__init__.py
@@ -11,16 +11,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """ pysper core package"""
-from collections import OrderedDict, Callable
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
+from collections import OrderedDict
+import copy
 
 class OrderedDefaultDict(OrderedDict):
+    """we were relying a lot on defaultdict for a variety
+    of functions supporting older versions of python
+    without order in dictionaries meant we had a lot of code
+    break that we had added since supporting 3.6+.
+    This gives us a way to have an ordereddict with default
+    behavior.
+    Source: http://stackoverflow.com/a/6190500/562769
+    """
 
-    # Source: http://stackoverflow.com/a/6190500/562769
+    #pylint: disable=keyword-arg-before-vararg
     def __init__(self, default_factory=None, *a, **kw):
-        if (default_factory is not None and
-           not isinstance(default_factory, Callable)):
+        if (default_factory is not None and not isinstance(default_factory, Callable)):
             raise TypeError('first argument must be callable')
         OrderedDict.__init__(self, *a, **kw)
         self.default_factory = default_factory
@@ -41,7 +52,7 @@ class OrderedDefaultDict(OrderedDict):
         if self.default_factory is None:
             args = tuple()
         else:
-            args = self.default_factory,
+            args = (self.default_factory, None)
         return type(self), args, None, None, self.items()
 
     def copy(self):
@@ -51,7 +62,6 @@ class OrderedDefaultDict(OrderedDict):
         return type(self)(self.default_factory, self)
 
     def __deepcopy__(self, memo):
-        import copy
         return type(self)(self.default_factory,
                           copy.deepcopy(self.items()))
 

--- a/pysper/core/diag/__init__.py
+++ b/pysper/core/diag/__init__.py
@@ -46,7 +46,7 @@ def warn_missing(node_configs, file_list, warnings, text):
     if not file_list:
         warnings.append("%s: all nodes" % text)
         return
-    nodes = [n for n in node_configs]
+    nodes = node_configs.keys()
     nodes_files = [util.extract_node_name(f) for f in file_list]
     nodes_missing = [n for n in nodes if n not in nodes_files]
     if nodes_missing:

--- a/pysper/core/diag/config_diff.py
+++ b/pysper/core/diag/config_diff.py
@@ -15,11 +15,12 @@
 """formats the output of the diag parsed data"""
 import json
 import operator
+from collections import OrderedDict
 
 IGNORE_LIST = ['nodes_list', 'nodes']
 
 def _get_common_configs(node_configs):
-    common_config = {}
+    common_config = OrderedDict()
     for i, node in enumerate(node_configs.keys()):
         if i == 0:
             #first configuration sets the base config
@@ -32,7 +33,7 @@ def _get_common_configs(node_configs):
                 common_jvm_args = common_config.get("jvm_args")
                 if not common_jvm_args:
                     continue
-                new_common_jvm_args = {}
+                new_common_jvm_args = OrderedDict()
                 for arg, jvm_value in value.items():
                     common_jvm_value = common_jvm_args.get(arg)
                     if common_jvm_value == jvm_value:
@@ -50,7 +51,7 @@ def filter_unique_jvm_flags(jvm_flags):
          '-Djdk.internal.lambda.dumpProxyClasses', \
          '-XX:ErrorFile', '-Ddse.system_memory_in_mb',\
     ]
-    return {x: y for (x, y) in jvm_flags.items() if x not in always_unique_jvm_flags}
+    return OrderedDict([x for x in jvm_flags.items() if x[0] not in always_unique_jvm_flags])
 
 def filter_unique_config_flags(node_config_params):
     """filters out the always unique config params from configuration comparision"""
@@ -63,7 +64,7 @@ def filter_unique_config_flags(node_config_params):
             'audit_logging_options', 'transparent_data_encryption_options', \
             'initial_token', \
     ]
-    return {x: y for (x, y) in node_config_params.items() if x not in always_unique_conf}
+    return OrderedDict([x for x in node_config_params.items() if x[0] not in always_unique_conf])
 
 def _add_diff_from_common(node_configs):
     common_config = _get_common_configs(node_configs)
@@ -88,7 +89,7 @@ def _add_diff_from_common(node_configs):
 
 def group_configurations(node_configs):
     """compares common configurations"""
-    configurations = {}
+    configurations = OrderedDict()
     _add_diff_from_common(node_configs)
     for node, config in node_configs.items():
         key = json.dumps(config["diff"])

--- a/pysper/core/diag/read_ahead.py
+++ b/pysper/core/diag/read_ahead.py
@@ -30,7 +30,7 @@ def get_cass_drive_read_ahead(node_info_json, block_dev_reports):
         return {}
     for node in node_info:
         drives = {}
-        drive_data  = node_info.get(node, {}).get('partitions', {}).get('data', {})
+        drive_data = node_info.get(node, {}).get('partitions', {}).get('data', {})
         if drive_data is None:
             continue
         for drive in drive_data:

--- a/pysper/core/statuslogger.py
+++ b/pysper/core/statuslogger.py
@@ -14,7 +14,7 @@
 
 """ pysper statuslogger module """
 import re
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 from pysper import VERSION
 from pysper import env
 from pysper import parser
@@ -131,6 +131,7 @@ class Summary:
 class StatusLogger:
     """ status logger """
 
+    # pylint: disable=too-many-arguments
     def __init__(self, diag_dir, files=None, start=None, end=None, \
          wanted_stages=WANTED_STAGES_PREFIXES, command_name="sperf core statuslogger",
                  syslog_prefix="system.log", dbglog_prefix="debug.log"):
@@ -154,6 +155,7 @@ class StatusLogger:
             self.end = date_parse(end)
 
     # pylint: disable=too-many-branches
+    # pylint: disable=too-many-statements
     def analyze(self):
         """ analyze log files """
         if self.analyzed:

--- a/pysper/core/statuslogger.py
+++ b/pysper/core/statuslogger.py
@@ -14,7 +14,7 @@
 
 """ pysper statuslogger module """
 import re
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from pysper import VERSION
 from pysper import env
 from pysper import parser
@@ -23,6 +23,7 @@ from pysper.util import get_percentiles, get_percentile_headers, node_name
 from pysper.humanize import format_seconds, format_bytes, format_num, pad_table
 from pysper.recs import Engine, Stage
 from pysper.dates import date_parse
+from pysper.core import OrderedDefaultDict
 
 WANTED_STAGES_PREFIXES = ('TPC/all/READ', 'TPC/all/WRITE', 'Gossip', 'Messaging',
                           'Compaction', 'MemtableFlush', 'Mutation', 'Read', 'Native')
@@ -40,8 +41,8 @@ class Node:
     def __init__(self):
         self.start = None
         self.end = None
-        self.tables = defaultdict(Table)
-        self.stages = defaultdict(lambda: defaultdict(list))
+        self.tables = OrderedDefaultDict(Table)
+        self.stages = OrderedDefaultDict(lambda: defaultdict(list))
         self.pauses = []
         self.version = None
         self.lines = 0

--- a/pysper/recs.py
+++ b/pysper/recs.py
@@ -18,8 +18,9 @@ import sys
 
 class Stage:
     """stage dataclass"""
+    #pylint: disable=too-many-arguments
     def __init__(self, name="", active=0, pending=0,
-    local_backpressure=0, completed=0, blocked=0,
+                 local_backpressure=0, completed=0, blocked=0,
                  all_time_blocked=0):
         self.name = name
         self.active = active

--- a/pysper/recs.py
+++ b/pysper/recs.py
@@ -13,20 +13,21 @@
 # limitations under the License.
 
 """the recommendation engine for sperf"""
-from dataclasses import dataclass
-from enum import Enum, auto
+from enum import Enum
 import sys
 
-@dataclass
 class Stage:
     """stage dataclass"""
-    name: str
-    active: int
-    pending: int
-    local_backpressure: int
-    completed: int
-    blocked: int
-    all_time_blocked: int
+    def __init__(self, name="", active=0, pending=0,
+    local_backpressure=0, completed=0, blocked=0,
+                 all_time_blocked=0):
+        self.name = name
+        self.active = active
+        self.pending = pending
+        self.local_backpressure = local_backpressure
+        self.completed = completed
+        self.blocked = blocked
+        self.all_time_blocked = all_time_blocked
 
 class Engine:
     """stage analyzer will make recommendations on stages based on
@@ -128,10 +129,10 @@ def _calculate_eviction_state(node):
 
 class EvictionReason(Enum):
     """eviction reason for filter cache statistics"""
-    NONE = auto()
-    MIXED = auto()
-    ITEM = auto()
-    BYTE = auto()
+    NONE = 1
+    MIXED = 2
+    ITEM = 3
+    BYTE = 4
 
 def analyze_filter_cache_stats(node):
     """look at filter cache statistics and generate recommendations"""

--- a/pysper/search/queryscore.py
+++ b/pysper/search/queryscore.py
@@ -175,29 +175,34 @@ def generate_report(parsed):
 TOO_MANY_ROWS = 9999
 UNLIMITED = -1
 
+def _count_reason(reasons, key, count=1):
+    if key not in reasons:
+        reasons[key] = 0
+    reasons[key] += count
+
 def score_query(query):
     """gives the query a score based on the number of bad things going on"""
-    reasons = defaultdict(int)
+    reasons = OrderedDict()
     score = 0
     for limit in query.field_facet_limits:
         if limit == UNLIMITED:
             score += 1
-            reasons["unlimited facets"] += 1
+            _count_reason(reasons, "unlimited facets")
         if query.global_facet_limit == UNLIMITED:
             score += 1
-            reasons["unlimited facets"] += 1
+            _count_reason(reasons, "unlimited facets")
     pivot_depth = len(query.pivot_facets)
     if pivot_depth > 0:
         pivot_depth_score = math.exp(pivot_depth)
         score += pivot_depth_score
-        reasons["pivot facet"] = pivot_depth_score
+        _count_reason(reasons, "pivot facet", pivot_depth_score)
     if query.stats_active:
         score += 1
-        reasons["stats query"] += 1
+        _count_reason(reasons, "stats query")
     if query.rows > TOO_MANY_ROWS:
         modifier = round((float(query.rows) / float(TOO_MANY_ROWS)))
         score += modifier
-        reasons["10k+ rows"] = modifier
+        _count_reason(reasons,  "10k+ rows", modifier)
     return score, reasons
 
 def clean(query_params):

--- a/pysper/search/queryscore.py
+++ b/pysper/search/queryscore.py
@@ -14,7 +14,7 @@
 
 """the solrqueryagg library"""
 import math
-from collections import namedtuple, defaultdict
+from collections import namedtuple, defaultdict, OrderedDict
 from operator import attrgetter
 from pysper import diag, util, parser
 
@@ -129,7 +129,7 @@ def get_bad_query_summary(queries_above_threshold, total):
 def add_body(queries_above_threshold, unique_reasons, top_n_worst):
     """adds the report body"""
     builder = []
-    visited_reasons = {}
+    visited_reasons = OrderedDict()
     count = 0
     for query_score in queries_above_threshold:
         reasons_array = []

--- a/pysper/ttop.py
+++ b/pysper/ttop.py
@@ -14,12 +14,13 @@
 
 """ ttop file analyzer """
 import re
-from collections import defaultdict
+from collections import OrderedDict 
 from pysper.parser.rules import date
 from pysper.util import textbar
 from pysper.dates import date_parse
 from pysper.humanize import format_bytes
 from pysper import env, VERSION
+from pysper.core import OrderedDefaultDict
 
 class TTopParser:
     """ parses ttop output files """
@@ -60,8 +61,8 @@ class TTopParser:
     # pylint: disable=too-many-statements, too-many-branches
     def parse(self, log):
         """ parse ttop output """
-        total = {}
-        threads = defaultdict(dict)
+        total = OrderedDict()
+        threads = OrderedDefaultDict(dict)
         for line in log:
             if self.state is None:
                 m = self.begin_match.match(line)
@@ -115,8 +116,8 @@ class TTopParser:
                 if line == '\n':
                     self.state = None
                     yield total, threads
-                    total = {}
-                    threads = defaultdict(dict)
+                    total = OrderedDict()
+                    threads = OrderedDefaultDict(dict)
                 else:
                     m = self.tinfo_match.match(line)
                     if not m:
@@ -143,7 +144,7 @@ class TTopAnalyzer:
 
     def collate_threads(self, threads):
         """ combines similar threads """
-        ret = defaultdict(lambda: defaultdict(float))
+        ret = OrderedDefaultDict(lambda: OrderedDefaultDict(float))
         exprs = []
         exprs.append(r':.*')
         exprs.append(r'-\d+.*')

--- a/pysper/ttop.py
+++ b/pysper/ttop.py
@@ -14,7 +14,7 @@
 
 """ ttop file analyzer """
 import re
-from collections import OrderedDict 
+from collections import OrderedDict
 from pysper.parser.rules import date
 from pysper.util import textbar
 from pysper.dates import date_parse

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ virtualenv==16.6.0
 wcwidth==0.1.7
 wrapt==1.11.1
 zipp==0.5.1
+tox==3.16.1

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,13 @@
 """setup script for sperf"""
 
 from setuptools import setup
+#setuptools import is needed on 3.5
+#pylint: disable=unused-import
 import setuptools
 
 setup(
     name='sperf',
-    version='0.6.0',
+    version='0.6.1-MASTER',
     description='Diagnostic utility for DSE and Cassandra',
     url='https://www.github.com/DataStax-Toolkit/sperf',
     app=["sperf.py"],

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 """setup script for sperf"""
 
 from setuptools import setup
+import setuptools
 
 setup(
     name='sperf',
@@ -8,6 +9,6 @@ setup(
     description='Diagnostic utility for DSE and Cassandra',
     url='https://www.github.com/DataStax-Toolkit/sperf',
     app=["sperf.py"],
-    setup_requires=['PyInstaller', 'tox'],
+    setup_requires=['PyInstaller', 'pytest'],
     package_dir={'': 'pysper'},
 )

--- a/tests/core/diag/test_config_diff.py
+++ b/tests/core/diag/test_config_diff.py
@@ -14,17 +14,14 @@
 
 """validate the config_diff module"""
 from pysper.core.diag import config_diff
+from collections import OrderedDict
 
 def test_group_configurations():
     """all grouped"""
-    node_config = {
-        "node1": {
-            "abc": "xyz",
-                },
-        "node2": {
-            "abc": "xyz",
-            },
-        }
+    node_config = OrderedDict([
+        ("node1", OrderedDict([("abc", "xyz")])),
+        ("node2", OrderedDict([("abc", "xyz")]))
+        ])
     groups = config_diff.group_configurations(node_config)
     assert len(groups) == 1
     first_group = groups[0]
@@ -34,14 +31,10 @@ def test_group_configurations():
 
 def test_group_configurations_with_diffs():
     """one of each"""
-    node_config = {
-        "node1": {
-            "abc": "zzz",
-                },
-        "node2": {
-            "abc": "xyz",
-            },
-        }
+    node_config = OrderedDict([
+        ("node1", OrderedDict([("abc", "zzz")])),
+        ("node2", OrderedDict([("abc", "xyz")]))
+        ])
     groups = config_diff.group_configurations(node_config)
     assert len(groups) == 2
     first_group = groups[0]

--- a/tests/core/diag/test_config_diff.py
+++ b/tests/core/diag/test_config_diff.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 """validate the config_diff module"""
-from pysper.core.diag import config_diff
 from collections import OrderedDict
+from pysper.core.diag import config_diff
 
 def test_group_configurations():
     """all grouped"""

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+# content of: tox.ini , put in same dir as setup.py
+[tox]
+envlist = py35,py36,py37,py38
+
+[testenv]
+# install pytest in the virtualenv where commands will be executed
+deps = 
+	 -rrequirements.txt
+commands =
+    # NOTE: you can run any command line tool here - not just tests
+    pytest


### PR DESCRIPTION
* Added tests for tox
* created a OrderedDefaultDict since we relied on the post 3.6 dictionary behavior to have order.
* statuslogger, filtercache, queryscore, ttop and the diag diff all use dictionaries with order now
* this should allow more people just to run sperf from source