### PR TITLE
Allow for more permissive date parsing

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 ## Install
 
-[Binaries here](https://github.com/DataStax-Toolkit/sperf/releases) or if you use [Hombrew](https://brew.sh) `brew tap foundev/sperf && brew install sperf`
+[Binaries here](https://github.com/DataStax-Toolkit/sperf/releases) or if you use [Hombrew](https://brew.sh) `brew tap rsds143/sperf && brew install sperf`
 
 ## What can it do
 

--- a/pysper/commands/sperf.py
+++ b/pysper/commands/sperf.py
@@ -55,6 +55,12 @@ def _build_sperf_cmd():
         action="store_true",
         help="set log format to EU. Is ignored by sysbottle which has it's own logging engine",
     )
+    parser.add_argument(
+        "-pt" "--permissive-time",
+        dest="permissive_time",
+        action="store_true",
+        help="allow partial timestamps for commandline arguments",
+    )
     sperf_default.build(parser)
     return parser, parser.add_subparsers(title="Commands")
 
@@ -79,6 +85,8 @@ def run():
         env.DEBUG = args.debug
     if args.eu:
         env.IS_US_FMT = False
+    if args.permissive_time:
+        env.PERMISSIVE_TIME = True
     if hasattr(args, "func"):
         try:
             args.func(args)

--- a/pysper/dates.py
+++ b/pysper/dates.py
@@ -69,17 +69,31 @@ class LogDateFormatParser:
         parsed_second = 0
         parsed_microsecond = 0
         try:
+            parsed_year = int(time_str[:4])
+            parsed_month = int(time_str[self.mp : self.mp + 2])
+            parsed_day = int(time_str[self.dp : self.dp + 2])
+        except:
+            msg = "unable to parse date in '%s'" % (time_str)
+            raise Exception(msg)
+        try:
             parsed_hour = int(time_str[11:13])
             parsed_minute = int(time_str[14:16])
             parsed_second = int(time_str[17:19])
             parsed_microsecond = int(time_str[20:23]) * 1000
-        except ValueError:
-            pass
+        except ValueError as e:
+            if not env.PERMISSIVE_TIME:
+                msg = (
+                    "unable to parse timestamp in '%s'. " % (time_str)
+                    + "If this is a desired partial timestamp, you can rerun with "
+                    + "'sperf --permissive-time <subcommand>' to ignore. "
+                    + "Error was %s" % (e)
+                )
+                raise Exception(msg)
         try:
             parsed = datetime(
-                year=int(time_str[:4]),
-                month=int(time_str[self.mp : self.mp + 2]),
-                day=int(time_str[self.dp : self.dp + 2]),
+                year=parsed_year,
+                month=parsed_month,
+                day=parsed_day,
                 hour=parsed_hour,
                 minute=parsed_minute,
                 second=parsed_second,
@@ -92,7 +106,7 @@ class LogDateFormatParser:
                 fmt = "us"
                 fix = "-e "
             msg = (
-                "invalid date, current mode log format "
+                "invalid datetime, current mode log format "
                 + "is %s. Try to rerun with sperf %s<subcommand> error was %s"
                 % (fmt, fix, e)
             )

--- a/pysper/dates.py
+++ b/pysper/dates.py
@@ -72,8 +72,8 @@ class LogDateFormatParser:
             parsed_year = int(time_str[:4])
             parsed_month = int(time_str[self.mp : self.mp + 2])
             parsed_day = int(time_str[self.dp : self.dp + 2])
-        except:
-            msg = "unable to parse date in '%s'" % (time_str)
+        except ValueError as e:
+            msg = "unable to parse date in '%s'. " % (time_str) + "Error was %s" % (e)
             raise Exception(msg)
         try:
             parsed_hour = int(time_str[11:13])

--- a/pysper/dates.py
+++ b/pysper/dates.py
@@ -64,15 +64,26 @@ class LogDateFormatParser:
         """ParseTimestamp creates a LogTimestamp based on the
         CASSANDRA_LOG_FORMAT and assumes UTC timezone always"""
         parsed = None
+        parsed_hour = 0
+        parsed_minute = 0
+        parsed_second = 0
+        parsed_microsecond = 0
+        try:
+            parsed_hour = int(time_str[11:13])
+            parsed_minute = int(time_str[14:16])
+            parsed_second = int(time_str[17:19])
+            parsed_microsecond = int(time_str[20:23]) * 1000
+        except ValueError:
+            pass
         try:
             parsed = datetime(
-                int(time_str[:4]),
-                int(time_str[self.mp : self.mp + 2]),
-                int(time_str[self.dp : self.dp + 2]),
-                int(time_str[11:13]),
-                int(time_str[14:16]),
-                int(time_str[17:19]),
-                int(time_str[20:23]) * 1000,
+                year=int(time_str[:4]),
+                month=int(time_str[self.mp : self.mp + 2]),
+                day=int(time_str[self.dp : self.dp + 2]),
+                hour=parsed_hour,
+                minute=parsed_minute,
+                second=parsed_second,
+                microsecond=parsed_microsecond,
             )
         except ValueError as e:
             fmt = "eu"

--- a/pysper/env.py
+++ b/pysper/env.py
@@ -18,3 +18,4 @@ PROGRESS = False
 DEBUG = False
 IS_US_FMT = True
 FILE_ENCODING = "utf-8"
+PERMISSIVE_TIME = False

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -72,3 +72,53 @@ class TestDates(unittest.TestCase):
             )
         finally:
             env.IS_US_FMT = orig
+
+    def test_us_dates_with_incomplete_timestamp(self):
+        """allow users to supply partial timestamps"""
+        orig = env.IS_US_FMT
+        try:
+            env.IS_US_FMT = True
+            parser = dates.LogDateFormatParser()
+            parsed = parser.parse_timestamp("2018-10-23")
+            self.assertEqual(
+                parsed.strftime("%Y-%m-%d %H:%M:%S,%f"), "2018-10-23 00:00:00,000000"
+            )
+            parsed = parser.parse_timestamp("2018-10-23 15:")
+            self.assertEqual(
+                parsed.strftime("%Y-%m-%d %H:%M:%S,%f"), "2018-10-23 15:00:00,000000"
+            )
+            parsed = parser.parse_timestamp("2018-10-23 15:50")
+            self.assertEqual(
+                parsed.strftime("%Y-%m-%d %H:%M:%S,%f"), "2018-10-23 15:50:00,000000"
+            )
+            parsed = parser.parse_timestamp("2018-10-23 15:50:01")
+            self.assertEqual(
+                parsed.strftime("%Y-%m-%d %H:%M:%S,%f"), "2018-10-23 15:50:01,000000"
+            )
+        finally:
+            env.IS_US_FMT = orig
+
+    def test_european_dates_with_incomplete_timestamp(self):
+        """allow users to supply partial timestamps"""
+        orig = env.IS_US_FMT
+        try:
+            env.IS_US_FMT = False
+            parser = dates.LogDateFormatParser()
+            parsed = parser.parse_timestamp("2018-23-10")
+            self.assertEqual(
+                parsed.strftime("%Y-%m-%d %H:%M:%S,%f"), "2018-10-23 00:00:00,000000"
+            )
+            parsed = parser.parse_timestamp("2018-23-10 15:")
+            self.assertEqual(
+                parsed.strftime("%Y-%m-%d %H:%M:%S,%f"), "2018-10-23 15:00:00,000000"
+            )
+            parsed = parser.parse_timestamp("2018-23-10 15:50")
+            self.assertEqual(
+                parsed.strftime("%Y-%m-%d %H:%M:%S,%f"), "2018-10-23 15:50:00,000000"
+            )
+            parsed = parser.parse_timestamp("2018-23-10 15:50:01")
+            self.assertEqual(
+                parsed.strftime("%Y-%m-%d %H:%M:%S,%f"), "2018-10-23 15:50:01,000000"
+            )
+        finally:
+            env.IS_US_FMT = orig

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -73,11 +73,13 @@ class TestDates(unittest.TestCase):
         finally:
             env.IS_US_FMT = orig
 
-    def test_us_dates_with_incomplete_timestamp(self):
+    def test_us_dates_with_permissive_time(self):
         """allow users to supply partial timestamps"""
         orig = env.IS_US_FMT
+        orig_pt = env.PERMISSIVE_TIME
         try:
             env.IS_US_FMT = True
+            env.PERMISSIVE_TIME = True
             parser = dates.LogDateFormatParser()
             parsed = parser.parse_timestamp("2018-10-23")
             self.assertEqual(
@@ -97,12 +99,15 @@ class TestDates(unittest.TestCase):
             )
         finally:
             env.IS_US_FMT = orig
+            env.PERMISSIVE_TIME = orig_pt
 
-    def test_european_dates_with_incomplete_timestamp(self):
+    def test_european_dates_with_permissive_time(self):
         """allow users to supply partial timestamps"""
         orig = env.IS_US_FMT
+        orig_pt = env.PERMISSIVE_TIME
         try:
             env.IS_US_FMT = False
+            env.PERMISSIVE_TIME = True
             parser = dates.LogDateFormatParser()
             parsed = parser.parse_timestamp("2018-23-10")
             self.assertEqual(
@@ -122,3 +127,4 @@ class TestDates(unittest.TestCase):
             )
         finally:
             env.IS_US_FMT = orig
+            env.PERMISSIVE_TIME = orig_pt


### PR DESCRIPTION
-   Allow for no time passed i.e. "2020-09-22"
-   Allow for partial time i.e. "2020-09-22 16:24"
-   Add testing coverage

More generally (separators can be anything):
US format:  year-month-day [hour][-min][-sec][-millis]
EU format:  year-day-month [hour][-min][-sec][-millis]

This should not impact performance as we are still not using datetime.strptime, https://github.com/DataStax-Toolkit/sperf/pull/22. Additional overhead should be negligible.