### PR TITLE
Fix #51. Add timeformat help messages

### DIFF
--- a/pysper/commands/core/bgrep.py
+++ b/pysper/commands/core/bgrep.py
@@ -40,7 +40,7 @@ def add_flags(subparsers, run_func):
         nargs="?",
         const=None,
         default=None,
-        help="start date/time to begin parsing",
+        help="start date/time to begin parsing (format: YYYY-MM-DD hh:mm:ss,SSS)",
     )
     bgrep_parser.add_argument(
         "-et",
@@ -49,7 +49,7 @@ def add_flags(subparsers, run_func):
         nargs="?",
         const=None,
         default=None,
-        help="end date/time to stop parsing",
+        help="end date/time to stop parsing (format: YYYY-MM-DD hh:mm:ss,SSS)",
     )
     bgrep_parser.add_argument(
         "-c", "--case", dest="case", action="store_true", help="case-sensitive search"

--- a/pysper/commands/core/gc.py
+++ b/pysper/commands/core/gc.py
@@ -57,7 +57,7 @@ def add_flags(subparsers, run_func):
         nargs="?",
         const=None,
         default=None,
-        help="start date/time to begin parsing",
+        help="start date/time to begin parsing (format: YYYY-MM-DD hh:mm:ss,SSS)",
     )
     gc_parser.add_argument(
         "-et",
@@ -66,7 +66,7 @@ def add_flags(subparsers, run_func):
         nargs="?",
         const=None,
         default=None,
-        help="end date/time to stop parsing",
+        help="end date/time to stop parsing (format: YYYY-MM-DD hh:mm:ss,SSS)",
     )
     flags.add_diagdir(gc_parser)
     flags.add_files(gc_parser)

--- a/pysper/commands/core/slowquery.py
+++ b/pysper/commands/core/slowquery.py
@@ -51,7 +51,7 @@ def add_flags(subparsers, run_default_func, is_deprecated=True):
         nargs="?",
         const=None,
         default=None,
-        help="start date/time to begin parsing",
+        help="start date/time to begin parsing (format: YYYY-MM-DD hh:mm:ss,SSS)",
     )
     slowquery_parser.add_argument(
         "-et",
@@ -60,7 +60,7 @@ def add_flags(subparsers, run_default_func, is_deprecated=True):
         nargs="?",
         const=None,
         default=None,
-        help="end date/time to stop parsing",
+        help="end date/time to stop parsing (format: YYYY-MM-DD hh:mm:ss,SSS)",
     )
     slowquery_parser.set_defaults(func=run_default_func)
 

--- a/pysper/commands/core/statuslogger.py
+++ b/pysper/commands/core/statuslogger.py
@@ -51,7 +51,7 @@ def add_flags(subparsers, run_default_func, is_deprecated=False):
         nargs="?",
         const=None,
         default=None,
-        help="start date/time to begin parsing",
+        help="start date/time to begin parsing (format: YYYY-MM-DD hh:mm:ss,SSS)",
     )
     statuslogger_parser.add_argument(
         "-et",
@@ -60,7 +60,7 @@ def add_flags(subparsers, run_default_func, is_deprecated=False):
         nargs="?",
         const=None,
         default=None,
-        help="end date/time to stop parsing",
+        help="end date/time to stop parsing (format: YYYY-MM-DD hh:mm:ss,SSS)",
     )
 
     statuslogger_parser.add_argument(

--- a/pysper/commands/search/filtercache.py
+++ b/pysper/commands/search/filtercache.py
@@ -43,13 +43,15 @@ def add_flags(subparsers, run_func, is_deprecated=False):
         "-a",
         "--after",
         default="0001-01-01 00:00:00,000000",
-        help="optional filter for log times to only look at " + "logs after this time",
+        help="optional filter for log times to only look at logs after this time "
+        + "(format: YYYY-MM-DD hh:mm:ss,SSS)",
     )
     filtercache_parser.add_argument(
         "-b",
         "--before",
         default="9999-12-31 23:59:59,999999",
-        help="optional filter for log times to only look at " + "logs before this time",
+        help="optional filter for log times to only look at logs before this time "
+        + "(format: YYYY-MM-DD hh:mm:ss,SSS)",
     )
     filtercache_parser.set_defaults(func=run_func)
 

--- a/pysper/commands/sperf.py
+++ b/pysper/commands/sperf.py
@@ -59,7 +59,8 @@ def _build_sperf_cmd():
         "-pt" "--permissive-time",
         dest="permissive_time",
         action="store_true",
-        help="allow partial timestamps for commandline arguments",
+        help="allow partial timestamps for commandline arguments "
+        + "(time format: YYYY-MM-DD [hh[:mm[:ss[,SSS]]]])",
     )
     sperf_default.build(parser)
     return parser, parser.add_subparsers(title="Commands")

--- a/pysper/commands/ttop.py
+++ b/pysper/commands/ttop.py
@@ -57,7 +57,7 @@ def build(subparsers):
         nargs="?",
         const=None,
         default=None,
-        help="start date/time to begin parsing",
+        help="start date/time to begin parsing (format: YYYY-MM-DD hh:mm:ss,SSS)",
     )
     ttop_parser.add_argument(
         "-et",
@@ -66,7 +66,7 @@ def build(subparsers):
         nargs="?",
         const=None,
         default=None,
-        help="end date/time to stop parsing",
+        help="end date/time to stop parsing (format: YYYY-MM-DD hh:mm:ss,SSS)",
     )
     ttop_parser.set_defaults(func=run)
 


### PR DESCRIPTION
Appending the expected formats to help messages for the following commands:
- core bgrep
- core gc
- core slowquery
- core statuslogger
- search filtercache
- ttop
- sperf --permissive-time