### PR TITLE
Fix filtercache bytes duration

### DIFF
--- a/pysper/dates.py
+++ b/pysper/dates.py
@@ -63,7 +63,6 @@ class LogDateFormatParser:
     def parse_timestamp(self, time_str):
         """ParseTimestamp creates a LogTimestamp based on the
         CASSANDRA_LOG_FORMAT and assumes UTC timezone always"""
-        parsed = None
         parsed_hour = 0
         parsed_minute = 0
         parsed_second = 0
@@ -99,6 +98,7 @@ class LogDateFormatParser:
                 second=parsed_second,
                 microsecond=parsed_microsecond,
             )
+            return parsed.replace(tzinfo=timezone.utc)
         except ValueError as e:
             fmt = "eu"
             fix = ""
@@ -111,4 +111,3 @@ class LogDateFormatParser:
                 % (fmt, fix, e)
             )
             raise Exception(msg)
-        return parsed.replace(tzinfo=timezone.utc)

--- a/pysper/parser/cases.py
+++ b/pysper/parser/cases.py
@@ -128,7 +128,7 @@ def solr_rules():
             update(
                 event_product="solr",
                 event_category="filter_cache",
-                event_type="eviction_items_duration",
+                event_type="eviction_duration",
             ),
         ),
         rule(
@@ -140,17 +140,6 @@ def solr_rules():
                 event_product="solr",
                 event_category="filter_cache",
                 event_type="eviction_bytes",
-            ),
-        ),
-        rule(
-            capture(
-                r"...eviction completed in (?P<duration>[0-9]+) milliseconds. Filter cache org.apache.solr.search.SolrFilterCache\$(?P<id>\S+) usage is now (?P<usage>[0-9]+) across (?P<entries>[0-9]+) entries."
-            ),
-            convert(int, "duration", "entries", "usage"),
-            update(
-                event_product="solr",
-                event_category="filter_cache",
-                event_type="eviction_bytes_duration",
             ),
         ),
         case("QueryComponent"),

--- a/pysper/parser/cases.py
+++ b/pysper/parser/cases.py
@@ -131,6 +131,18 @@ def solr_rules():
                 event_type="eviction_duration",
             ),
         ),
+        # log pattern for DSE before DSP-18693
+        rule(
+            capture(
+                r"...eviction completed in (?P<duration>[0-9]+) milliseconds. Filter cache org.apache.solr.search.SolrFilterCache\$(?P<id>\S+) usage is now (?P<usage>[0-9]+) across (?P<entries>[0-9]+) entries."
+            ),
+            convert(int, "duration", "entries", "usage"),
+            update(
+                event_product="solr",
+                event_category="filter_cache",
+                event_type="eviction_duration",
+            ),
+        ),
         rule(
             capture(
                 r"Filter cache org.apache.solr.search.SolrFilterCache\$(?P<id>\S+) has reached (?P<usage>[0-9]+) (?P<usage_unit>\w+) bytes of off-heap memory usage, the maximum is (?P<maximum>[0-9]+) (?P<maximum_unit>\w+). Evicting oldest entries..."

--- a/pysper/parser/cases.py
+++ b/pysper/parser/cases.py
@@ -122,16 +122,16 @@ def solr_rules():
         ),
         rule(
             capture(
-                r"...eviction completed in (?P<duration>[0-9]+) milliseconds. Filter cache org.apache.solr.search.SolrFilterCache\$(?P<id>\S+) usage is now (?P<usage>[0-9]+) (?P<usage_unit>\w+) across (?P<entries>[0-9]+) entries."
+                r"Filter cache org.apache.solr.search.SolrFilterCache\$(?P<id>\S+) has reached (?P<usage>[0-9]+) (?P<usage_unit>\w+) bytes of off-heap memory usage, the maximum is (?P<maximum>[0-9]+) (?P<maximum_unit>\w+). Evicting oldest entries..."
             ),
-            convert(int, "duration", "entries", "usage"),
+            convert(int, "maximum", "usage"),
             update(
                 event_product="solr",
                 event_category="filter_cache",
-                event_type="eviction_duration",
+                event_type="eviction_bytes",
             ),
         ),
-        # log pattern for DSE before DSP-18693
+        # eviction duration log pattern for DSE before DSP-18693
         rule(
             capture(
                 r"...eviction completed in (?P<duration>[0-9]+) milliseconds. Filter cache org.apache.solr.search.SolrFilterCache\$(?P<id>\S+) usage is now (?P<usage>[0-9]+) across (?P<entries>[0-9]+) entries."
@@ -143,15 +143,16 @@ def solr_rules():
                 event_type="eviction_duration",
             ),
         ),
+        # new eviction duration log pattern after DSP-18693
         rule(
             capture(
-                r"Filter cache org.apache.solr.search.SolrFilterCache\$(?P<id>\S+) has reached (?P<usage>[0-9]+) (?P<usage_unit>\w+) bytes of off-heap memory usage, the maximum is (?P<maximum>[0-9]+) (?P<maximum_unit>\w+). Evicting oldest entries..."
+                r"...eviction completed in (?P<duration>[0-9]+) milliseconds. Filter cache org.apache.solr.search.SolrFilterCache\$(?P<id>\S+) usage is now (?P<usage>[0-9]+) (?P<usage_unit>\w+) across (?P<entries>[0-9]+) entries."
             ),
-            convert(int, "maximum", "usage"),
+            convert(int, "duration", "entries", "usage"),
             update(
                 event_product="solr",
                 event_category="filter_cache",
-                event_type="eviction_bytes",
+                event_type="eviction_duration",
             ),
         ),
         case("QueryComponent"),

--- a/pysper/search/filtercache.py
+++ b/pysper/search/filtercache.py
@@ -156,6 +156,24 @@ def _get_stats(events, ctor, key_name):
     return eviction_stats
 
 
+def calculate_eviction_stats(raw_events, after_time, before_time):
+    assert after_time < before_time
+    filter_cache_events = [
+        event
+        for event in raw_events
+        if event.get("event_category", "") == "filter_cache"
+           and "date" in event
+           and after_time < event["date"] < before_time
+    ]
+    item_eviction_stats = _get_stats(
+        filter_cache_events, ItemFCStats, "eviction_items"
+    )
+    bytes_eviction_stats = _get_stats(
+        filter_cache_events, BytesFCStats, "eviction_bytes"
+    )
+    return (item_eviction_stats, bytes_eviction_stats)
+
+
 def parse(args):
     """parse entry point, generates a report object
     from a tarball or series of files"""
@@ -172,28 +190,11 @@ def parse(args):
         start_log_time, last_log_time = diag.log_range(log)
         with diag.FileWithProgress(log) as log_file:
             raw_events = parser.read_system_log(log_file)
-            filter_cache_events_all = [
-                event
-                for event in raw_events
-                if event.get("event_category", "") == "filter_cache"
-            ]
-            filter_cache_events = [
-                event
-                for event in filter_cache_events_all
-                if "date" in event
-                and event["date"] > after_time
-                and event["date"] < before_time
-            ]
-            item_eviction_stats = _get_stats(
-                filter_cache_events, ItemFCStats, "eviction_items"
-            )
-            bytes_eviction_stats = _get_stats(
-                filter_cache_events, BytesFCStats, "eviction_bytes"
-            )
+            item_ev_stats, bytes_ev_stats = calculate_eviction_stats(raw_events, after_time, before_time)
             node = util.extract_node_name(log, True)
             node_stats[node] = OrderedDict(
                 [
-                    ("evictions", (bytes_eviction_stats, item_eviction_stats)),
+                    ("evictions", (bytes_ev_stats, item_ev_stats)),
                     ("start", start_log_time),
                     ("end", last_log_time),
                 ]

--- a/pysper/search/filtercache.py
+++ b/pysper/search/filtercache.py
@@ -66,7 +66,7 @@ class NodeReportBlock:
             self.avg_evict_duration,
             self.byte_limit,
             self.item_limit,
-            self.evict_range,
+            int(self.evict_range),
         )
 
 
@@ -129,6 +129,7 @@ class ItemFCStats:
 
 def _get_stats(events, ctor, key_name):
     """adds the corresponding duration event.
+
     Note the the get_id hack is error prone when spanning logs as half an event could not finish
     """
     eviction_stats = {
@@ -143,7 +144,7 @@ def _get_stats(events, ctor, key_name):
             [
                 event
                 for event in events
-                if event.get("event_type", "") == (key_name + "_duration")
+                if event.get("event_type", "") == "eviction_duration"
             ]
         )
     }

--- a/pysper/search/filtercache.py
+++ b/pysper/search/filtercache.py
@@ -162,12 +162,10 @@ def calculate_eviction_stats(raw_events, after_time, before_time):
         event
         for event in raw_events
         if event.get("event_category", "") == "filter_cache"
-           and "date" in event
-           and after_time < event["date"] < before_time
+        and "date" in event
+        and after_time < event["date"] < before_time
     ]
-    item_eviction_stats = _get_stats(
-        filter_cache_events, ItemFCStats, "eviction_items"
-    )
+    item_eviction_stats = _get_stats(filter_cache_events, ItemFCStats, "eviction_items")
     bytes_eviction_stats = _get_stats(
         filter_cache_events, BytesFCStats, "eviction_bytes"
     )
@@ -190,7 +188,9 @@ def parse(args):
         start_log_time, last_log_time = diag.log_range(log)
         with diag.FileWithProgress(log) as log_file:
             raw_events = parser.read_system_log(log_file)
-            item_ev_stats, bytes_ev_stats = calculate_eviction_stats(raw_events, after_time, before_time)
+            item_ev_stats, bytes_ev_stats = calculate_eviction_stats(
+                raw_events, after_time, before_time
+            )
             node = util.extract_node_name(log, True)
             node_stats[node] = OrderedDict(
                 [

--- a/tests/parser/test_systemlog.py
+++ b/tests/parser/test_systemlog.py
@@ -61,7 +61,7 @@ class TestSystemParser(unittest.TestCase):
             # old version of logs, before DSP-18693
             "INFO  [RemoteMessageServer query worker - 41] 2020-01-21 12:47:26,950  SolrFilterCache.java:328 - ...eviction completed in 9 milliseconds. Filter cache org.apache.solr.search.SolrFilterCache$6@5af917a4 usage is now 114781220 across 159 entries.",
             # new version of logs, after DSP-18693
-            "INFO  [RemoteMessageServer query worker - 41] 2020-01-21 12:47:26,950  SolrFilterCache.java:328 - ...eviction completed in 8 milliseconds. Filter cache org.apache.solr.search.SolrFilterCache$6@5af917a4 usage is now 114781220 bytes across 159 entries.",
+            "INFO  [RemoteMessageServer query worker - 41] 2020-01-21 12:47:26,950  SolrFilterCache.java:328 - ...eviction completed in 8 milliseconds. Filter cache org.apache.solr.search.SolrFilterCache$6@5af917b6 usage is now 114781220 bytes across 159 entries.",
         ]
         events = []
         for line in lines:
@@ -97,4 +97,4 @@ class TestSystemParser(unittest.TestCase):
         self.assertEqual(events[7]["duration"], 8)
         self.assertEqual(events[7]["usage"], 114781220)
         self.assertEqual(events[7]["entries"], 159)
-        self.assertEqual(events[7]["id"], "6@5af917a4")
+        self.assertEqual(events[7]["id"], "6@5af917b6")

--- a/tests/parser/test_systemlog.py
+++ b/tests/parser/test_systemlog.py
@@ -56,9 +56,9 @@ class TestSystemParser(unittest.TestCase):
             "ERROR [RemoteMessageServer query worker - 18] 2020-01-21 11:34:34,475  MessageServer.java:277 - Failed to process request:",
             "INFO  [RemoteMessageServer query worker - 81] 2020-01-21 11:34:35,448  SolrFilterCache.java:356 - ...eviction completed in 1304 milliseconds. Filter cache org.apache.solr.search.SolrFilterCache$1@7c723229 usage is now 32441266 bytes across 4000000 entries.",
             "INFO  [LocalMessageServer query worker - 77] 2020-01-21 12:24:23,912  SolrFilterCache.java:340 - Filter cache org.apache.solr.search.SolrFilterCache$1@324b2c16 has reached 3999974 entries of a maximum of 8000000. Evicting oldest entries...",
-            "INFO  [LocalMessageServer query worker - 77] 2020-01-21 12:24:23,912  SolrFilterCache.java:356 - ...eviction completed in 0 milliseconds. Filter cache org.apache.solr.search.SolrFilterCache$1@324b2c16 usage is now 32005744 bytes across 3999962 entries.",
+            "INFO  [LocalMessageServer query worker - 77] 2020-01-21 12:24:23,912  SolrFilterCache.java:356 - ...eviction completed in 1 milliseconds. Filter cache org.apache.solr.search.SolrFilterCache$1@324b2c16 usage is now 32005744 bytes across 3999962 entries.",
             "INFO  [RemoteMessageServer query worker - 41] 2020-01-21 12:47:26,942  SolrFilterCache.java:311 - Filter cache org.apache.solr.search.SolrFilterCache$6@5af917a4 has reached 16 GB bytes of off-heap memory usage, the maximum is 16 GB. Evicting oldest entries...",
-            "INFO  [RemoteMessageServer query worker - 41] 2020-01-21 12:47:26,950  SolrFilterCache.java:328 - ...eviction completed in 9 milliseconds. Filter cache org.apache.solr.search.SolrFilterCache$6@5af917a4 usage is now 114781220 across 159 entries.",
+            "INFO  [RemoteMessageServer query worker - 41] 2020-01-21 12:47:26,950  SolrFilterCache.java:328 - ...eviction completed in 9 milliseconds. Filter cache org.apache.solr.search.SolrFilterCache$6@5af917a4 usage is now 114781220 bytes across 159 entries.",
         ]
         events = []
         for line in lines:
@@ -78,7 +78,7 @@ class TestSystemParser(unittest.TestCase):
         self.assertEqual(events[3]["maximum"], 8000000)
         self.assertEqual(events[3]["id"], "1@324b2c16")
         self.assertEqual(events[4]["entries"], 3999962)
-        self.assertEqual(events[4]["duration"], 0)
+        self.assertEqual(events[4]["duration"], 1)
         self.assertEqual(events[4]["usage"], 32005744)
         self.assertEqual(events[4]["usage_unit"], "bytes")
         self.assertEqual(events[4]["id"], "1@324b2c16")

--- a/tests/parser/test_systemlog.py
+++ b/tests/parser/test_systemlog.py
@@ -58,13 +58,16 @@ class TestSystemParser(unittest.TestCase):
             "INFO  [LocalMessageServer query worker - 77] 2020-01-21 12:24:23,912  SolrFilterCache.java:340 - Filter cache org.apache.solr.search.SolrFilterCache$1@324b2c16 has reached 3999974 entries of a maximum of 8000000. Evicting oldest entries...",
             "INFO  [LocalMessageServer query worker - 77] 2020-01-21 12:24:23,912  SolrFilterCache.java:356 - ...eviction completed in 1 milliseconds. Filter cache org.apache.solr.search.SolrFilterCache$1@324b2c16 usage is now 32005744 bytes across 3999962 entries.",
             "INFO  [RemoteMessageServer query worker - 41] 2020-01-21 12:47:26,942  SolrFilterCache.java:311 - Filter cache org.apache.solr.search.SolrFilterCache$6@5af917a4 has reached 16 GB bytes of off-heap memory usage, the maximum is 16 GB. Evicting oldest entries...",
-            "INFO  [RemoteMessageServer query worker - 41] 2020-01-21 12:47:26,950  SolrFilterCache.java:328 - ...eviction completed in 9 milliseconds. Filter cache org.apache.solr.search.SolrFilterCache$6@5af917a4 usage is now 114781220 bytes across 159 entries.",
+            # old version of logs, before DSP-18693
+            "INFO  [RemoteMessageServer query worker - 41] 2020-01-21 12:47:26,950  SolrFilterCache.java:328 - ...eviction completed in 9 milliseconds. Filter cache org.apache.solr.search.SolrFilterCache$6@5af917a4 usage is now 114781220 across 159 entries.",
+            # new version of logs, after DSP-18693
+            "INFO  [RemoteMessageServer query worker - 41] 2020-01-21 12:47:26,950  SolrFilterCache.java:328 - ...eviction completed in 8 milliseconds. Filter cache org.apache.solr.search.SolrFilterCache$6@5af917a4 usage is now 114781220 bytes across 159 entries.",
         ]
         events = []
         for line in lines:
             event = systemlog.capture_line(line)
             events.append(event)
-        self.assertEqual(len(events), 7)
+        self.assertEqual(len(events), len(lines))
         self.assertEqual(events[0]["maximum"], 8000000)
         self.assertEqual(events[0]["entries"], 8000000)
         self.assertEqual(events[0]["id"], "1@7c723229")
@@ -91,3 +94,7 @@ class TestSystemParser(unittest.TestCase):
         self.assertEqual(events[6]["usage"], 114781220)
         self.assertEqual(events[6]["entries"], 159)
         self.assertEqual(events[6]["id"], "6@5af917a4")
+        self.assertEqual(events[7]["duration"], 8)
+        self.assertEqual(events[7]["usage"], 114781220)
+        self.assertEqual(events[7]["entries"], 159)
+        self.assertEqual(events[7]["id"], "6@5af917a4")

--- a/tests/search/test_filtercache.py
+++ b/tests/search/test_filtercache.py
@@ -116,9 +116,10 @@ NOTE: Do top recommendation first.
         raw_events = parser.read_system_log(lines)
         after_time = dates.date_parse("2020-01-21 00:00:00,000")
         before_time = dates.date_parse("2020-02-21 00:00:00,000")
-        item_ev_stats, bytes_ev_stats = calculate_eviction_stats(raw_events, after_time, before_time)
+        item_ev_stats, bytes_ev_stats = calculate_eviction_stats(
+            raw_events, after_time, before_time
+        )
         assert len(item_ev_stats.values()) == 2
         assert sum([s.duration for s in item_ev_stats.values()]) == 1304 + 1
         assert len(bytes_ev_stats.values()) == 3
         assert sum([s.duration for s in bytes_ev_stats.values()]) == 9 + 8 + 0
-

--- a/tests/search/test_filtercache.py
+++ b/tests/search/test_filtercache.py
@@ -15,7 +15,9 @@
 """tests the filter cache file parsing and report generation"""
 import unittest
 import types
-from pysper.search.filtercache import generate_recommendations
+
+from pysper import parser, dates
+from pysper.search.filtercache import generate_recommendations, calculate_eviction_stats
 
 
 def _build_node(name, avg_evict_freq=10.0, avg_evict_duration=500.0):
@@ -95,3 +97,28 @@ NOTE: Do top recommendation first.
             report[2],
         )
         self.assertNotIn("NOTE: Do top recommendation first.", report)
+
+    def test_calculate_eviction_stats(self):
+        lines = [
+            "INFO  [RemoteMessageServer query worker - 81] 2020-01-21 11:34:33,033  SolrFilterCache.java:340 - Filter cache org.apache.solr.search.SolrFilterCache$1@7c723229 has reached 8000000 entries of a maximum of 8000000. Evicting oldest entries...",
+            "ERROR [RemoteMessageServer query worker - 18] 2020-01-21 11:34:34,475  MessageServer.java:277 - Failed to process request:",
+            "INFO  [RemoteMessageServer query worker - 81] 2020-01-21 11:34:35,448  SolrFilterCache.java:356 - ...eviction completed in 1304 milliseconds. Filter cache org.apache.solr.search.SolrFilterCache$1@7c723229 usage is now 32441266 bytes across 4000000 entries.",
+            "INFO  [LocalMessageServer query worker - 77] 2020-01-21 12:24:23,912  SolrFilterCache.java:340 - Filter cache org.apache.solr.search.SolrFilterCache$1@324b2c16 has reached 3999974 entries of a maximum of 8000000. Evicting oldest entries...",
+            "INFO  [LocalMessageServer query worker - 77] 2020-01-21 12:24:23,912  SolrFilterCache.java:356 - ...eviction completed in 1 milliseconds. Filter cache org.apache.solr.search.SolrFilterCache$1@324b2c16 usage is now 32005744 bytes across 3999962 entries.",
+            "INFO  [RemoteMessageServer query worker - 41] 2020-01-21 12:47:26,942  SolrFilterCache.java:311 - Filter cache org.apache.solr.search.SolrFilterCache$6@5af917a4 has reached 16 GB bytes of off-heap memory usage, the maximum is 16 GB. Evicting oldest entries...",
+            "INFO  [RemoteMessageServer query worker - 41] 2020-01-21 12:47:26,950  SolrFilterCache.java:328 - ...eviction completed in 9 milliseconds. Filter cache org.apache.solr.search.SolrFilterCache$6@5af917a4 usage is now 114781220 across 159 entries.",
+            # new version of logs, after DSP-18693
+            "INFO  [RemoteMessageServer query worker - 41] 2020-01-21 12:47:26,942  SolrFilterCache.java:311 - Filter cache org.apache.solr.search.SolrFilterCache$6@5af917b6 has reached 16 GB bytes of off-heap memory usage, the maximum is 16 GB. Evicting oldest entries...",
+            "INFO  [RemoteMessageServer query worker - 41] 2020-01-21 12:47:26,950  SolrFilterCache.java:328 - ...eviction completed in 8 milliseconds. Filter cache org.apache.solr.search.SolrFilterCache$6@5af917b6 usage is now 114781220 bytes across 159 entries.",
+            # eviction event without duration log line
+            "INFO  [RemoteMessageServer query worker - 41] 2020-01-21 12:47:26,970  SolrFilterCache.java:311 - Filter cache org.apache.solr.search.SolrFilterCache$6@5af917c7 has reached 16 GB bytes of off-heap memory usage, the maximum is 16 GB. Evicting oldest entries...",
+        ]
+        raw_events = parser.read_system_log(lines)
+        after_time = dates.date_parse("2020-01-21 00:00:00,000")
+        before_time = dates.date_parse("2020-02-21 00:00:00,000")
+        item_ev_stats, bytes_ev_stats = calculate_eviction_stats(raw_events, after_time, before_time)
+        assert len(item_ev_stats.values()) == 2
+        assert sum([s.duration for s in item_ev_stats.values()]) == 1304 + 1
+        assert len(bytes_ev_stats.values()) == 3
+        assert sum([s.duration for s in bytes_ev_stats.values()]) == 9 + 8 + 0
+


### PR DESCRIPTION
This is a fix for #68 

The idea of the fix to have only one type of the event: `eviction_duration` and match by `id`.
This will work fine if we have IDs correctly generated.
Enumeration trick will probably not work.

DSP-18693 unified the message about the duration. So it is same for both size and memory-based since 5.1.13, 6.0.10, 6.7.5 and 6.8.0.