### PR TITLE
Updated changelog.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 
-.PHONY: all build lint cov
-all: clean lint cov build
+.PHONY: all
+all: clean update_change lint cov build
 	#do it all
 
 ifeq ($(OS),Windows_NT) 
@@ -12,6 +12,7 @@ pysper_dir := .\\pysper
 perf_script := .\\scripts\\sperf
 sperf_zip := .\\dist\\sperf-Windows
 sperf_exe := .\\dist\\sperf.exe
+update_change := .\\scripts\update_change.py
 else
 del_exec := rm -fr 
 test_dir := ./tests
@@ -19,7 +20,12 @@ pysper_dir := ./pysper
 sperf_script := ./scripts/sperf
 sperf_zip := ./dist/sperf-$(shell sh -c 'uname 2>/dev/null || echo Unknown')
 sperf_exe := ./dist/sperf
+update_change := ./scripts/update_change.py
 endif
+
+.PHONY: update_change
+update_change:
+	$(update_change)
 
 .PHONY: clean
 clean:
@@ -27,7 +33,7 @@ clean:
 	$(del_exec) dist
 
 .PHONY: build
-build:
+build: update_change
 	pyinstaller -F $(sperf_script)
 	7z a -tzip $(sperf_zip) $(sperf_exe) -mx0
 

--- a/pysper/changelog.py
+++ b/pysper/changelog.py
@@ -6,6 +6,8 @@ of DSE 5.1.17, 6.0.10, 6.7.5 and 6.8.0
 * new makefile for build dependencies
 * updated changelog to be accurate
 * sperf version outputs changelog and version
+* removed support and testing for Python 3.6
+* sperf script will now bomb if python 3.7 or greater is not installed
 
 sperf 0.6.13
 ------------

--- a/pysper/changelog.py
+++ b/pysper/changelog.py
@@ -1,3 +1,4 @@
+CHANGES = """
 sperf 0.6.14
 ------------
 * sperf was not parsing new byte eviction format as of in sperf filtercache as
@@ -5,8 +6,6 @@ of DSE 5.1.17, 6.0.10, 6.7.5 and 6.8.0
 * new makefile for build dependencies
 * updated changelog to be accurate
 * sperf version outputs changelog and version
-* removed support and testing for Python 3.6
-* sperf script will now bomb if python 3.7 or greater is not installed
 
 sperf 0.6.13
 ------------
@@ -32,7 +31,7 @@ sperf 0.6.9
 * removed stale node_name util
 * filter cache time series
 * get full directory instead of .
-* ttop handles more files now 
+* ttop handles more files now
 
 sperf 0.6.8
 -----------
@@ -67,7 +66,7 @@ sperf 0.6.4
 default. Added additional testing to validate there is no double counting.
 * DSE 6.8 `sperf core statuslogger` support
 * DSE 6.8 additional testing for `sperf core diag`, `sperf core schema`,
-`sperf core slowquery` and the default `sperf` command 
+`sperf core slowquery` and the default `sperf` command
 * `sperf core statuslogger` now defaults to showing all stages to give a more
 full explanation of what is going on by default. Most people didn't know the 'all stages' flag existed
 and this is largely to force people to narrow their search intentionally. The initial experience maybe overwhelming, but this will make it more likely people will catch outliers
@@ -104,3 +103,4 @@ sperf 0.6.1
 sperf 0.6.0
 -----------
 * initial open source release
+"""

--- a/pysper/commands/sperf.py
+++ b/pysper/commands/sperf.py
@@ -15,7 +15,7 @@
 """main sperf parent command"""
 import argparse
 from pysper import env, VERSION
-from pysper.commands import core, search, sysbottle, flags, ttop, sperf_default
+from pysper.commands import core, search, sysbottle, flags, ttop, sperf_default, version
 
 
 def _build_sperf_cmd():
@@ -73,6 +73,7 @@ def build_parser():
     search.build(subparsers)
     sysbottle.build(subparsers)
     ttop.build(subparsers)
+    version.build(subparsers)
     return parser
 
 

--- a/pysper/commands/version.py
+++ b/pysper/commands/version.py
@@ -27,5 +27,7 @@ def build(subparsers):
         formatter_class=flags.LineWrapRawTextHelpFormatter,
     )
     version_parser.set_defaults(
-            func=lambda _: print("sperf %s-%s\n\nchangelog:\n%s" % (VERSION, sys.version, CHANGES))
+        func=lambda _: print(
+            "sperf %s-%s\n\nchangelog:\n%s" % (VERSION, sys.version, CHANGES)
+        )
     )

--- a/pysper/commands/version.py
+++ b/pysper/commands/version.py
@@ -15,6 +15,7 @@
 """simple version output"""
 import sys
 from pysper import VERSION
+from pysper.changelog import CHANGES
 from pysper.commands import flags
 
 
@@ -26,5 +27,5 @@ def build(subparsers):
         formatter_class=flags.LineWrapRawTextHelpFormatter,
     )
     version_parser.set_defaults(
-        func=lambda _: print("sperf %s-%s", VERSION, sys.version)
+            func=lambda _: print("sperf %s-%s\n\nchangelog:\n%s" % (VERSION, sys.version, CHANGES))
     )

--- a/scripts/update_change.py
+++ b/scripts/update_change.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+with open("CHANGELOG.TXT", "r") as c:
+    with open("./pysper/changelog.py", "w") as w:
+        w.write('CHANGES = """\n')
+        for l in c:
+            w.write(l.strip() + "\n")
+        w.write('"""\n')
+        w.flush()


### PR DESCRIPTION
* updated changelog to be accurate
* sperf version outputs changelog and version
* removed support and testing for Python 3.6
* sperf script will now bomb if python 3.7 or greater is not installed